### PR TITLE
Strip HTML comments.

### DIFF
--- a/pkg/webhooks/github/actions/release_drafter.go
+++ b/pkg/webhooks/github/actions/release_drafter.go
@@ -347,7 +347,7 @@ func (r *releaseDrafter) appendPullRequest(org string, priorBody string, repo st
 
 	if prBody != nil {
 		issueSuffix := fmt.Sprintf("(%s/%s#%d)", org, repo, number)
-		_ = r.prependCodeBlocks(m, stripHtmlComments(*prBody), &issueSuffix)
+		_ = r.prependCodeBlocks(m, *prBody, &issueSuffix)
 	}
 
 	return m.String()
@@ -355,6 +355,7 @@ func (r *releaseDrafter) appendPullRequest(org string, priorBody string, repo st
 
 func (r *releaseDrafter) prependCodeBlocks(m *markdown.Markdown, body string, issueSuffix *string) error {
 	changed := false
+	body = stripHtmlComments(body)
 
 	for _, b := range blocks {
 		actionBlock, err := markdown.ExtractAnnotatedBlock(b.identifier, body)

--- a/pkg/webhooks/github/actions/release_drafter_test.go
+++ b/pkg/webhooks/github/actions/release_drafter_test.go
@@ -7,7 +7,12 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-cmp/cmp"
 	v3 "github.com/google/go-github/v57/github"
+
+	_ "embed"
 )
+
+//go:embed test/pr-template.md
+var prTemplate string
 
 func TestReleaseDrafter_updateReleaseBody(t *testing.T) {
 	tests := []struct {
@@ -186,6 +191,18 @@ Some description
 ### metal-robot v0.2.5
 * Fix (metal-stack/metal-robot#123) @Gerrit91`,
 		},
+		{
+			name:             "prevent pull request template with HTML body to be interpreted as release notes",
+			headline:         "General",
+			org:              "metal-stack",
+			component:        "metal-robot",
+			componentVersion: semver.MustParse("0.2.4"),
+			componentBody:    v3.String(prTemplate),
+			priorBody:        "",
+			want: `# General
+## Component Releases
+### metal-robot v0.2.4`,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -311,6 +328,18 @@ Some description
 ## Breaking Changes
 * API has changed (metal-stack/metal-robot#11)
 # Merged Pull Requests
+* Some new feature (metal-stack/metal-robot#11) @metal-robot`,
+		},
+		{
+			name:      "prevent pull request template with HTML body to be interpreted as release notes",
+			org:       "metal-stack",
+			repo:      "metal-robot",
+			title:     "Some new feature",
+			number:    11,
+			author:    "metal-robot",
+			priorBody: "",
+			prBody:    &prTemplate,
+			want: `# Merged Pull Requests
 * Some new feature (metal-stack/metal-robot#11) @metal-robot`,
 		},
 	}

--- a/pkg/webhooks/github/actions/test/pr-template.md
+++ b/pkg/webhooks/github/actions/test/pr-template.md
@@ -1,0 +1,60 @@
+## References
+
+Closes #issue.
+
+<!--
+Thanks for opening a pull request in the metal-stack org! 😻
+If you haven't done already, feel free to check our contribution guidelines on docs.metal-stack.io.
+
+If possible, please reference other issues or pull requests. If this PR closes an issue, please add:
+
+Closes #<the-issue-number-to-close>.
+
+If you want to reference other issues, please add:
+
+References:
+
+- ...
+
+If your PR depends on other PRs, please add:
+
+Depends on:
+
+- [ ] ...
+-->
+
+## Additional Description
+
+None
+
+<!--
+If not already described in a referenced issue, please describe your PR and the motivation behind it. You can also add special notes for the reviewers here, e.g. why you solved the problem in a certain why or give an overview over the your changes and implications. Just try to make life easy for the reviewers.
+-->
+
+## Release Notes
+
+None
+
+<!--
+Do you want to add something to the release notes (metal-stack/releases)? You can do so by adding special sections in this PR.
+
+Please be aware that the pull request's title will become part of the release notes, so try to make it understandable and choose wisely.
+
+If your changes contain a breaking change, please add the following section:
+
+## Breaking Change
+
+```BREAKING_CHANGE
+Description of the breaking change and what an operator needs to do about it.
+This section is **not** intended for documentation of internal breaking changes.
+Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
+```
+
+If your changes contain required actions for operators, please add the following section:
+
+## Required Actions
+
+```ACTIONS_REQUIRED
+Description of the required action.
+```
+-->


### PR DESCRIPTION
The metal-robot interprets contents from our new pull request template for the release notes, which is not ideal.
