### PR TITLE
Automatically remove triage label when changing item status.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,8 @@ require (
 
 replace github.com/google/go-github/v74 => github.com/gerrit91/go-github/v74 v74.0.0-20250725122512-42bbaeb22e64
 
+require github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
+
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0
 )
 
-replace github.com/google/go-github/v74 => github.com/gerrit91/go-github/v74 v74.0.0-20250724215748-5548f0b3dc65
+replace github.com/google/go-github/v74 => github.com/gerrit91/go-github/v74 v74.0.0-20250725122512-42bbaeb22e64
 
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -27,8 +27,6 @@ require (
 
 replace github.com/google/go-github/v74 => github.com/gerrit91/go-github/v74 v74.0.0-20250725122512-42bbaeb22e64
 
-require github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
-
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/go-playground/webhooks/v6 v6.4.0
 	github.com/google/go-cmp v0.7.0
-	github.com/google/go-github/v72 v72.0.0
+	github.com/google/go-github/v74 v74.0.0
 	github.com/metal-stack/metal-lib v0.23.0
 	github.com/metal-stack/v v1.0.3
 	github.com/mitchellh/mapstructure v1.5.0
@@ -25,6 +25,8 @@ require (
 	sigs.k8s.io/yaml v1.4.0
 )
 
+replace github.com/google/go-github/v74 => github.com/gerrit91/go-github/v74 v74.0.0-20250724215748-5548f0b3dc65
+
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
@@ -36,6 +38,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
+	github.com/google/go-github/v72 v72.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,8 @@ require (
 	sigs.k8s.io/yaml v1.4.0
 )
 
+// TODO: Hope this can be removed in a future release
+// https://github.com/google/go-github/pull/3650
 replace github.com/google/go-github/v74 => github.com/gerrit91/go-github/v74 v74.0.0-20250725122512-42bbaeb22e64
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
 github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
-github.com/gerrit91/go-github/v74 v74.0.0-20250724215748-5548f0b3dc65 h1:ThY9suK7Pdkm+pKeoP8ID8CE3Mx7jfHdPKpoAVrLIGI=
-github.com/gerrit91/go-github/v74 v74.0.0-20250724215748-5548f0b3dc65/go.mod h1:ubn/YdyftV80VPSI26nSJvaEsTOnsjrxG3o9kJhcyak=
+github.com/gerrit91/go-github/v74 v74.0.0-20250725122512-42bbaeb22e64 h1:ivnU++CAzCOebuwzfMnhnLFG69pgJVPrDOwRJrMFjX4=
+github.com/gerrit91/go-github/v74 v74.0.0-20250725122512-42bbaeb22e64/go.mod h1:ubn/YdyftV80VPSI26nSJvaEsTOnsjrxG3o9kJhcyak=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
 github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
+github.com/gerrit91/go-github/v74 v74.0.0-20250724215748-5548f0b3dc65 h1:ThY9suK7Pdkm+pKeoP8ID8CE3Mx7jfHdPKpoAVrLIGI=
+github.com/gerrit91/go-github/v74 v74.0.0-20250724215748-5548f0b3dc65/go.mod h1:ubn/YdyftV80VPSI26nSJvaEsTOnsjrxG3o9kJhcyak=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=

--- a/pkg/clients/github.go
+++ b/pkg/clients/github.go
@@ -9,7 +9,7 @@ import (
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/metal-stack/metal-robot/pkg/config"
 
-	"github.com/google/go-github/v72/github"
+	"github.com/google/go-github/v74/github"
 
 	"github.com/shurcooL/githubv4"
 )

--- a/pkg/config/actions.go
+++ b/pkg/config/actions.go
@@ -38,6 +38,11 @@ type ProjectItemAddHandlerConfig struct {
 	ProjectID string `mapstructure:"project-id" description:"the project in which to move newly created issues and pull requests"`
 }
 
+type ProjectV2ItemHandlerConfig struct {
+	ProjectID    string   `mapstructure:"project-id" description:"the project on which to handle item events"`
+	RemoveLabels []string `mapstructure:"remove-labels" description:"labels to remove if a project v2 item changes its field status from null to something"`
+}
+
 type DistributeReleasesConfig struct {
 	SourceRepositoryName string       `mapstructure:"repository" description:"the name of the source repo"`
 	SourceRepositoryURL  string       `mapstructure:"repository-url" description:"the url of the source repo"`

--- a/pkg/webhooks/github/actions/aggregate_releases.go
+++ b/pkg/webhooks/github/actions/aggregate_releases.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/atedja/go-multilock"
-	"github.com/google/go-github/v72/github"
+	"github.com/google/go-github/v74/github"
 	"github.com/metal-stack/metal-lib/pkg/pointer"
 	"github.com/metal-stack/metal-robot/pkg/clients"
 	"github.com/metal-stack/metal-robot/pkg/config"

--- a/pkg/webhooks/github/actions/aggregate_releases_test.go
+++ b/pkg/webhooks/github/actions/aggregate_releases_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v72/github"
+	"github.com/google/go-github/v74/github"
 	"github.com/metal-stack/metal-lib/pkg/pointer"
 )
 

--- a/pkg/webhooks/github/actions/common.go
+++ b/pkg/webhooks/github/actions/common.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/metal-stack/metal-robot/pkg/clients"
 	"github.com/metal-stack/metal-robot/pkg/config"
 	"github.com/metal-stack/metal-robot/pkg/webhooks/constants"
@@ -376,24 +375,6 @@ func (w *WebhookActions) ProcessProjectV2ItemEvent(ctx context.Context, payload 
 				return nil
 			}
 
-			// 			  "changes": {
-			//     "field_value": {
-			//       "field_node_id": "PVTSSF_lADOA4BFWM4A6z3RzgvS5v4",
-			//       "field_type": "single_select",
-			//       "field_name": "Status",
-			//       "project_number": 34,
-			//       "from": null,
-			//       "to": {
-			//         "id": "98236657",
-			//         "name": "Done",
-			//         "color": "RED",
-			//         "description": "This has been completed"
-			//       }
-			//     }
-			//   },
-
-			spew.Dump(payload)
-
 			if payload.Changes == nil ||
 				payload.Changes.FieldValue == nil ||
 				pointer.SafeDeref(payload.Changes.FieldValue.FieldName) != "Status" ||
@@ -413,13 +394,13 @@ func (w *WebhookActions) ProcessProjectV2ItemEvent(ctx context.Context, payload 
 			}
 
 			params := &projectV2ItemHandlerParams{
-				ProjectNumber: pointer.SafeDeref(payload.Changes.FieldValue.ProjectNumber), // TODO use node id as in other handler
-				ProjectID:     ActionProjectItemAddHandler,
+				ProjectNumber: pointer.SafeDeref(payload.Changes.FieldValue.ProjectNumber),
+				ProjectID:     pointer.SafeDeref(payload.ProjectV2Item.ProjectNodeID),
 				ContentNodeID: pointer.SafeDeref(payload.ProjectV2Item.ContentNodeID),
 			}
 			err = a.Handle(ctx, params)
 			if err != nil {
-				w.logger.Error("error removing labels from project v2 item", "project-number", params.ProjectNumber, "error", err)
+				w.logger.Error("error handling project v2 item", "project-number", params.ProjectNumber, "error", err)
 				return err
 			}
 

--- a/pkg/webhooks/github/actions/common.go
+++ b/pkg/webhooks/github/actions/common.go
@@ -370,7 +370,7 @@ func (w *WebhookActions) ProcessProjectV2ItemEvent(ctx context.Context, payload 
 
 	for _, a := range w.p2 {
 		g.Go(func() error {
-			if pointer.SafeDeref(payload.Action) != "edit" {
+			if pointer.SafeDeref(payload.Action) != "edited" {
 				return nil
 			}
 			if payload.Changes == nil ||

--- a/pkg/webhooks/github/actions/distribute_releases.go
+++ b/pkg/webhooks/github/actions/distribute_releases.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/atedja/go-multilock"
-	"github.com/google/go-github/v72/github"
+	"github.com/google/go-github/v74/github"
 	"github.com/metal-stack/metal-robot/pkg/clients"
 	"github.com/metal-stack/metal-robot/pkg/config"
 	"github.com/metal-stack/metal-robot/pkg/git"

--- a/pkg/webhooks/github/actions/docs_preview_comment.go
+++ b/pkg/webhooks/github/actions/docs_preview_comment.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/google/go-github/v72/github"
+	"github.com/google/go-github/v74/github"
 	"github.com/metal-stack/metal-robot/pkg/clients"
 	"github.com/metal-stack/metal-robot/pkg/config"
 	"github.com/mitchellh/mapstructure"

--- a/pkg/webhooks/github/actions/issue_comments_handler.go
+++ b/pkg/webhooks/github/actions/issue_comments_handler.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v72/github"
+	"github.com/google/go-github/v74/github"
 	"github.com/metal-stack/metal-robot/pkg/clients"
 	"github.com/metal-stack/metal-robot/pkg/config"
 	"github.com/metal-stack/metal-robot/pkg/git"

--- a/pkg/webhooks/github/actions/project_item_add_handler.go
+++ b/pkg/webhooks/github/actions/project_item_add_handler.go
@@ -20,7 +20,6 @@ type projectItemAdd struct {
 
 type projectItemAddParams struct {
 	RepositoryName string
-	RepositoryURL  string
 	NodeID         string
 	ID             int64
 	URL            string

--- a/pkg/webhooks/github/actions/project_v2_item_handler.go
+++ b/pkg/webhooks/github/actions/project_v2_item_handler.go
@@ -70,7 +70,7 @@ func (r *projectV2ItemHandler) Handle(ctx context.Context, p *projectV2ItemHandl
 	}
 
 	variables := map[string]any{
-		"node_id": githubv4.String(p.ContentNodeID),
+		"node_id": githubv4.ID(p.ContentNodeID),
 	}
 
 	err := r.graphql.Query(ctx, &q, variables)

--- a/pkg/webhooks/github/actions/project_v2_item_handler.go
+++ b/pkg/webhooks/github/actions/project_v2_item_handler.go
@@ -42,7 +42,7 @@ func newProjectV2ItemHandler(logger *slog.Logger, client *clients.Github, rawCon
 
 func (r *projectV2ItemHandler) Handle(ctx context.Context, p *projectV2ItemHandlerParams) error {
 	if p.ProjectID != r.projectID {
-		r.logger.Info("skip removing labels from project v2 item, not acting on specified project")
+		r.logger.Info("skip removing labels from project v2 item, wrong project-id")
 		return nil
 	}
 
@@ -117,7 +117,7 @@ func (r *projectV2ItemHandler) Handle(ctx context.Context, p *projectV2ItemHandl
 
 		r.logger.Info("removed labels from project v2 item", "labels", r.removeLabels, "project-number", r.projectID, "item-url", url)
 	} else {
-		r.logger.Info("no need to removed labels from project v2 item, none of them attached", "labels", r.removeLabels, "project-number", r.projectID, "item-url", url)
+		r.logger.Info("no need to removed labels from project v2 item, none of them are attached", "labels", r.removeLabels, "project-number", r.projectID, "item-url", url)
 	}
 
 	return nil

--- a/pkg/webhooks/github/actions/project_v2_item_handler.go
+++ b/pkg/webhooks/github/actions/project_v2_item_handler.go
@@ -42,7 +42,7 @@ func newProjectV2ItemHandler(logger *slog.Logger, client *clients.Github, rawCon
 
 func (r *projectV2ItemHandler) Handle(ctx context.Context, p *projectV2ItemHandlerParams) error {
 	if p.ProjectID != r.projectID {
-		r.logger.Info("skip removing labels from project v2 item, wrong project-id")
+		r.logger.Debug("skip removing labels from project v2 item, wrong project-id")
 		return nil
 	}
 

--- a/pkg/webhooks/github/actions/project_v2_item_handler.go
+++ b/pkg/webhooks/github/actions/project_v2_item_handler.go
@@ -14,7 +14,6 @@ import (
 
 type projectV2ItemHandler struct {
 	logger       *slog.Logger
-	client       *clients.Github
 	graphql      *githubv4.Client
 	projectID    string
 	removeLabels []string
@@ -35,7 +34,6 @@ func newProjectV2ItemHandler(logger *slog.Logger, client *clients.Github, rawCon
 
 	return &projectV2ItemHandler{
 		logger:       logger,
-		client:       client,
 		graphql:      client.GetGraphQLClient(),
 		projectID:    typedConfig.ProjectID,
 		removeLabels: typedConfig.RemoveLabels,

--- a/pkg/webhooks/github/actions/project_v2_item_handler.go
+++ b/pkg/webhooks/github/actions/project_v2_item_handler.go
@@ -117,7 +117,7 @@ func (r *projectV2ItemHandler) Handle(ctx context.Context, p *projectV2ItemHandl
 
 		r.logger.Info("removed labels from project v2 item", "labels", r.removeLabels, "project-number", r.projectID, "item-url", url)
 	} else {
-		r.logger.Info("no need to removed labels from project v2 item, none of them are attached", "labels", r.removeLabels, "project-number", r.projectID, "item-url", url)
+		r.logger.Info("no need to remove labels from project v2 item, none of them are attached", "labels", r.removeLabels, "project-number", r.projectID, "item-url", url)
 	}
 
 	return nil

--- a/pkg/webhooks/github/actions/project_v2_item_handler.go
+++ b/pkg/webhooks/github/actions/project_v2_item_handler.go
@@ -1,0 +1,126 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+
+	"github.com/metal-stack/metal-robot/pkg/clients"
+	"github.com/metal-stack/metal-robot/pkg/config"
+	"github.com/mitchellh/mapstructure"
+	"github.com/shurcooL/githubv4"
+)
+
+type projectV2ItemHandler struct {
+	logger       *slog.Logger
+	client       *clients.Github
+	graphql      *githubv4.Client
+	projectID    string
+	removeLabels []string
+}
+
+type projectV2ItemHandlerParams struct {
+	ProjectNumber int64
+	ProjectID     string
+	ContentNodeID string
+}
+
+func newProjectV2ItemHandler(logger *slog.Logger, client *clients.Github, rawConfig map[string]any) (*projectV2ItemHandler, error) {
+	var typedConfig config.ProjectV2ItemHandlerConfig
+	err := mapstructure.Decode(rawConfig, &typedConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &projectV2ItemHandler{
+		logger:       logger,
+		client:       client,
+		graphql:      client.GetGraphQLClient(),
+		projectID:    typedConfig.ProjectID,
+		removeLabels: typedConfig.RemoveLabels,
+	}, nil
+}
+
+func (r *projectV2ItemHandler) Handle(ctx context.Context, p *projectV2ItemHandlerParams) error {
+	if p.ProjectID != r.projectID {
+		r.logger.Info("skip removing labels from project v2 item, not acting on specified project")
+		return nil
+	}
+
+	var q struct {
+		Node struct {
+			PullRequest struct {
+				URL    string `graphql:"url"`
+				Labels struct {
+					Nodes []struct {
+						Name string `graphql:"name"`
+						ID   string `graphql:"id"`
+					} `graphql:"nodes"`
+				} `graphql:"labels(first: 20)"`
+			} `graphql:"... on PullRequest"`
+			Issue struct {
+				URL    string `graphql:"url"`
+				Labels struct {
+					Nodes []struct {
+						Name string `graphql:"name"`
+						ID   string `graphql:"id"`
+					} `graphql:"nodes"`
+				} `graphql:"labels(first: 20)"`
+			} `graphql:"... on Issue"`
+		} `graphql:"node(id: $node_id)"`
+	}
+
+	variables := map[string]any{
+		"node_id": githubv4.String(p.ContentNodeID),
+	}
+
+	err := r.graphql.Query(ctx, &q, variables)
+	if err != nil {
+		return fmt.Errorf("error querying graphql: %w", err)
+	}
+
+	var (
+		labelIDs []githubv4.ID
+		url      = q.Node.PullRequest.URL
+	)
+
+	if q.Node.Issue.URL != "" {
+		url = q.Node.Issue.URL
+	}
+
+	for _, n := range q.Node.PullRequest.Labels.Nodes {
+		if slices.Contains(r.removeLabels, n.Name) {
+			labelIDs = append(labelIDs, n.ID)
+		}
+	}
+	for _, n := range q.Node.Issue.Labels.Nodes {
+		if slices.Contains(r.removeLabels, n.Name) {
+			labelIDs = append(labelIDs, n.ID)
+		}
+	}
+
+	if len(labelIDs) > 0 {
+		var m struct {
+			RemoveLabelsFromLabelable struct {
+				ClientMutationId string `graphql:"clientMutationId"`
+			} `graphql:"removeLabelsFromLabelable(input: $input)"`
+		}
+
+		input := githubv4.RemoveLabelsFromLabelableInput{
+			LabelableID: p.ContentNodeID,
+			LabelIDs:    labelIDs,
+		}
+
+		err = r.graphql.Mutate(ctx, &m, input, nil)
+		if err != nil {
+			return fmt.Errorf("error mutating graphql: %w", err)
+		}
+
+		r.logger.Info("removed labels from project v2 item", "labels", r.removeLabels, "project-number", r.projectID, "item-url", url)
+	} else {
+		r.logger.Info("no need to removed labels from project v2 item, none of them attached", "labels", r.removeLabels, "project-number", r.projectID, "item-url", url)
+	}
+
+	return nil
+}

--- a/pkg/webhooks/github/actions/release_drafter.go
+++ b/pkg/webhooks/github/actions/release_drafter.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/google/go-github/v72/github"
+	"github.com/google/go-github/v74/github"
 	"github.com/metal-stack/metal-robot/pkg/clients"
 	"github.com/metal-stack/metal-robot/pkg/config"
 	"github.com/metal-stack/metal-robot/pkg/markdown"
@@ -280,7 +280,7 @@ func stripHtmlComments(s string) string {
 }
 
 // appends a merged pull request to the release draft
-func (r *releaseDrafter) appendMergedPR(ctx context.Context, title string, number int64, author string, p *releaseDrafterParams) error {
+func (r *releaseDrafter) appendMergedPR(ctx context.Context, title string, number int, author string, p *releaseDrafterParams) error {
 	_, ok := r.repoMap[p.RepositoryName]
 	if ok {
 		// if there is an ACTIONS_REQUIRED block, we want to add it (even when it's a release vector handled repository)
@@ -319,7 +319,7 @@ func (r *releaseDrafter) appendMergedPR(ctx context.Context, title string, numbe
 	return r.createOrUpdateRelease(ctx, infos, body, p)
 }
 
-func (r *releaseDrafter) appendPullRequest(org string, priorBody string, repo string, title string, number int64, author string, prBody *string) string {
+func (r *releaseDrafter) appendPullRequest(org string, priorBody string, repo string, title string, number int, author string, prBody *string) string {
 	m := markdown.Parse(priorBody)
 
 	l := fmt.Sprintf("* %s (%s/%s#%d) @%s", title, org, repo, number, author)

--- a/pkg/webhooks/github/actions/release_drafter_test.go
+++ b/pkg/webhooks/github/actions/release_drafter_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v72/github"
+	"github.com/google/go-github/v74/github"
 
 	_ "embed"
 )
@@ -232,7 +232,7 @@ func Test_releaseDrafter_appendPullRequest(t *testing.T) {
 		org         string
 		repo        string
 		title       string
-		number      int64
+		number      int
 		author      string
 		prBody      *string
 		priorBody   string

--- a/pkg/webhooks/github/actions/repository_maintainers.go
+++ b/pkg/webhooks/github/actions/repository_maintainers.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/google/go-github/v72/github"
+	"github.com/google/go-github/v74/github"
 	"github.com/metal-stack/metal-robot/pkg/clients"
 	"github.com/metal-stack/metal-robot/pkg/config"
 	"github.com/mitchellh/mapstructure"

--- a/pkg/webhooks/github/actions/yaml_translate_releases.go
+++ b/pkg/webhooks/github/actions/yaml_translate_releases.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/atedja/go-multilock"
-	"github.com/google/go-github/v72/github"
+	"github.com/google/go-github/v74/github"
 	"github.com/metal-stack/metal-robot/pkg/clients"
 	"github.com/metal-stack/metal-robot/pkg/config"
 	"github.com/metal-stack/metal-robot/pkg/git"

--- a/pkg/webhooks/github/github.go
+++ b/pkg/webhooks/github/github.go
@@ -51,34 +51,34 @@ func (w *Webhook) Handle(response http.ResponseWriter, request *http.Request) {
 
 	ctx := context.Background()
 	switch event := event.(type) {
-	case github.ReleaseEvent:
+	case *github.ReleaseEvent:
 		w.logger.Debug("received release event")
 		// nolint:contextcheck
-		go w.a.ProcessReleaseEvent(ctx, &event)
-	case github.PullRequestEvent:
+		go w.a.ProcessReleaseEvent(ctx, event)
+	case *github.PullRequestEvent:
 		w.logger.Debug("received pull request event")
 		// nolint:contextcheck
-		go w.a.ProcessPullRequestEvent(ctx, &event)
-	case github.PushEvent:
+		go w.a.ProcessPullRequestEvent(ctx, event)
+	case *github.PushEvent:
 		w.logger.Debug("received push event")
 		// nolint:contextcheck
-		go w.a.ProcessPushEvent(ctx, &event)
-	case github.IssuesEvent:
+		go w.a.ProcessPushEvent(ctx, event)
+	case *github.IssuesEvent:
 		w.logger.Debug("received issues event")
 		// nolint:contextcheck
-		go w.a.ProcessIssuesEvent(ctx, &event)
-	case github.IssueCommentEvent:
+		go w.a.ProcessIssuesEvent(ctx, event)
+	case *github.IssueCommentEvent:
 		w.logger.Debug("received issue comment event")
 		// nolint:contextcheck
-		go w.a.ProcessIssueCommentEvent(ctx, &event)
-	case github.RepositoryEvent:
+		go w.a.ProcessIssueCommentEvent(ctx, event)
+	case *github.RepositoryEvent:
 		w.logger.Debug("received repository event")
 		// nolint:contextcheck
-		go w.a.ProcessRepositoryEvent(ctx, &event)
-	case github.ProjectV2ItemEvent:
+		go w.a.ProcessRepositoryEvent(ctx, event)
+	case *github.ProjectV2ItemEvent:
 		w.logger.Debug("received project v2 item event")
 		// nolint:contextcheck
-		go w.a.ProcessProjectV2ItemEvent(ctx, &event)
+		go w.a.ProcessProjectV2ItemEvent(ctx, event)
 	default:
 		w.logger.Warn("missing handler for webhook event", "event-type", github.WebHookType(request))
 	}

--- a/pkg/webhooks/github/github.go
+++ b/pkg/webhooks/github/github.go
@@ -80,7 +80,7 @@ func (w *Webhook) Handle(response http.ResponseWriter, request *http.Request) {
 		// nolint:contextcheck
 		go w.a.ProcessProjectV2ItemEvent(ctx, &event)
 	default:
-		w.logger.Warn("missing handler", "payload", string(payload))
+		w.logger.Warn("missing handler for webhook event", "event-type", github.WebHookType(request))
 	}
 
 	response.WriteHeader(http.StatusOK)

--- a/pkg/webhooks/github/github.go
+++ b/pkg/webhooks/github/github.go
@@ -2,39 +2,24 @@ package github
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"net/http"
 
-	ghwebhooks "github.com/go-playground/webhooks/v6/github"
+	"github.com/google/go-github/v74/github"
 	"github.com/metal-stack/metal-robot/pkg/clients"
 	"github.com/metal-stack/metal-robot/pkg/config"
 	"github.com/metal-stack/metal-robot/pkg/webhooks/github/actions"
 )
 
-var listenEvents = []ghwebhooks.Event{
-	ghwebhooks.ReleaseEvent,
-	ghwebhooks.PullRequestEvent,
-	ghwebhooks.PushEvent,
-	ghwebhooks.IssuesEvent,
-	ghwebhooks.IssueCommentEvent,
-	ghwebhooks.RepositoryEvent,
-}
-
 type Webhook struct {
 	logger *slog.Logger
 	cs     clients.ClientMap
-	hook   *ghwebhooks.Webhook
 	a      *actions.WebhookActions
+	secret string
 }
 
 // NewGithubWebhook returns a new webhook controller
 func NewGithubWebhook(logger *slog.Logger, w config.Webhook, cs clients.ClientMap) (*Webhook, error) {
-	hook, err := ghwebhooks.New(ghwebhooks.Options.Secret(w.Secret))
-	if err != nil {
-		return nil, err
-	}
-
 	a, err := actions.InitActions(logger, cs, w.Actions)
 	if err != nil {
 		return nil, err
@@ -43,7 +28,7 @@ func NewGithubWebhook(logger *slog.Logger, w config.Webhook, cs clients.ClientMa
 	controller := &Webhook{
 		logger: logger,
 		cs:     cs,
-		hook:   hook,
+		secret: w.Secret,
 		a:      a,
 	}
 
@@ -52,46 +37,50 @@ func NewGithubWebhook(logger *slog.Logger, w config.Webhook, cs clients.ClientMa
 
 // Handle handles github webhook events
 func (w *Webhook) Handle(response http.ResponseWriter, request *http.Request) {
-	payload, err := w.hook.Parse(request, listenEvents...)
+	payload, err := github.ValidatePayload(request, []byte(w.secret))
 	if err != nil {
-		if errors.Is(err, ghwebhooks.ErrEventNotFound) {
-			w.logger.Warn("received unregistered github event", "error", err)
-			response.WriteHeader(http.StatusOK)
-		} else {
-			w.logger.Error("received malformed github event", "error", err)
-			response.WriteHeader(http.StatusInternalServerError)
-		}
-		return
+		w.logger.Error("received invalid github event", "error", err)
+		response.WriteHeader(http.StatusInternalServerError)
+	}
+
+	event, err := github.ParseWebHook(github.WebHookType(request), payload)
+	if err != nil {
+		w.logger.Error("received unrecognized github event type", "error", err)
+		response.WriteHeader(http.StatusInternalServerError)
 	}
 
 	ctx := context.Background()
-	switch payload := payload.(type) {
-	case ghwebhooks.ReleasePayload:
+	switch event := event.(type) {
+	case github.ReleaseEvent:
 		w.logger.Debug("received release event")
 		// nolint:contextcheck
-		go w.a.ProcessReleaseEvent(ctx, &payload)
-	case ghwebhooks.PullRequestPayload:
+		go w.a.ProcessReleaseEvent(ctx, &event)
+	case github.PullRequestEvent:
 		w.logger.Debug("received pull request event")
 		// nolint:contextcheck
-		go w.a.ProcessPullRequestEvent(ctx, &payload)
-	case ghwebhooks.PushPayload:
+		go w.a.ProcessPullRequestEvent(ctx, &event)
+	case github.PushEvent:
 		w.logger.Debug("received push event")
 		// nolint:contextcheck
-		go w.a.ProcessPushEvent(ctx, &payload)
-	case ghwebhooks.IssuesPayload:
+		go w.a.ProcessPushEvent(ctx, &event)
+	case github.IssuesEvent:
 		w.logger.Debug("received issues event")
 		// nolint:contextcheck
-		go w.a.ProcessIssuesEvent(ctx, &payload)
-	case ghwebhooks.IssueCommentPayload:
+		go w.a.ProcessIssuesEvent(ctx, &event)
+	case github.IssueCommentEvent:
 		w.logger.Debug("received issue comment event")
 		// nolint:contextcheck
-		go w.a.ProcessIssueCommentEvent(ctx, &payload)
-	case ghwebhooks.RepositoryPayload:
+		go w.a.ProcessIssueCommentEvent(ctx, &event)
+	case github.RepositoryEvent:
 		w.logger.Debug("received repository event")
 		// nolint:contextcheck
-		go w.a.ProcessRepositoryEvent(ctx, &payload)
+		go w.a.ProcessRepositoryEvent(ctx, &event)
+	case github.ProjectV2ItemEvent:
+		w.logger.Debug("received project v2 item event")
+		// nolint:contextcheck
+		go w.a.ProcessProjectV2ItemEvent(ctx, &event)
 	default:
-		w.logger.Warn("missing handler", "payload", payload)
+		w.logger.Warn("missing handler", "payload", string(payload))
 	}
 
 	response.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Description

Closes #80.

Unfortunately, I had to change quite a lot to make this happen.

First, I had to fork go-github and add a missing property on the `ProjectV2Item` changed event: https://github.com/google/go-github/pull/3650.

Then the `go-playground/webhooks` dependency does not provide the webhook event for project v2 items. In general this project does not seem to be maintained a lot. The go-github dependency also provides a possibility to parse these webhook events and is more complete, so I changed everything to go-github. The disadvantage is that all their fields are pointers. :see_no_evil: 

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
