### PR TITLE
Fix release drafter merges sections on common component prefixes.

### DIFF
--- a/pkg/webhooks/github/actions/release_drafter.go
+++ b/pkg/webhooks/github/actions/release_drafter.go
@@ -236,7 +236,8 @@ func (r *releaseDrafter) updateReleaseBody(org string, priorBody string, compone
 	}
 
 	heading := fmt.Sprintf("%s v%s", component, componentVersion.String())
-	section := m.FindSectionByHeadingPrefix(3, component)
+	section := m.FindSectionByHeadingPrefix(3, component+" v")
+
 	if section == nil {
 		componentSection.AppendChild(&markdown.MarkdownSection{
 			Level:        3,

--- a/pkg/webhooks/github/actions/release_drafter_test.go
+++ b/pkg/webhooks/github/actions/release_drafter_test.go
@@ -203,9 +203,28 @@ Some description
 ## Component Releases
 ### metal-robot v0.2.4`,
 		},
+		{
+			name:             "similar namings of a repo",
+			headline:         "General",
+			org:              "metal-stack",
+			component:        "metal-api",
+			componentVersion: semver.MustParse("0.2.4"),
+			componentBody:    github.Ptr(`- Something`),
+			priorBody: `# General
+## Component Releases
+### metal-apiserver v0.11.7
+- Adding new feature
+- Fixed a bug`,
+			want: `# General
+## Component Releases
+### metal-apiserver v0.11.7
+- Adding new feature
+- Fixed a bug
+### metal-api v0.2.4
+- Something`,
+		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			r := &releaseDrafter{
 				logger:        slog.Default(),
@@ -359,7 +378,6 @@ Some description
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				r := &releaseDrafter{


### PR DESCRIPTION
## Description

Closes #85.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
