### PR TITLE
Small fork build improvements for issues handler.

### DIFF
--- a/pkg/webhooks/github/actions/issue_comments_handler.go
+++ b/pkg/webhooks/github/actions/issue_comments_handler.go
@@ -147,6 +147,7 @@ func (r *IssueCommentsAction) buildForkPR(ctx context.Context, p *IssueCommentsA
 		Base:                pullRequest.Base.Ref,
 		Body:                github.Ptr("Fork build for #" + prNumber + " triggered by @" + p.User),
 		MaintainerCanModify: github.Ptr(true),
+		Draft:               github.Ptr(true),
 	})
 	if err != nil {
 		if !strings.Contains(err.Error(), "A pull request already exists") {

--- a/pkg/webhooks/github/actions/issue_comments_handler.go
+++ b/pkg/webhooks/github/actions/issue_comments_handler.go
@@ -154,20 +154,7 @@ func (r *IssueCommentsAction) buildForkPR(ctx context.Context, p *IssueCommentsA
 		}
 	}
 
-	// and immediately close this PR again, it's just for building...
-	forkPr.State = github.Ptr("closed")
-
-	_, _, err = r.client.GetV3Client().PullRequests.Edit(ctx, r.client.Organization(), p.RepositoryName, *forkPr.Number, forkPr)
-	if err != nil {
-		return err
-	}
-
 	r.logger.Info("triggered fork build action by pushing to fork-build branch", "source-repo", p.RepositoryName, "branch", forkBuildBranch, "pull-request-url", forkPr.GetURL())
-
-	_, _, err = r.client.GetV3Client().Reactions.CreateIssueCommentReaction(ctx, r.client.Organization(), p.RepositoryName, p.CommentID, "rocket")
-	if err != nil {
-		return fmt.Errorf("error creating issue comment reaction %w", err)
-	}
 
 	return nil
 }


### PR DESCRIPTION
## Description

Recently I had to use the feature again for building a PR from a fork of an external contributor. 

It's not beneficial to directly close the fork build PR because you do not have direct access to the build artifacts anymore when a PR is closed.

Secondly, the comment reaction is not necessary because the fork build PR references the original PR and this way you can already see it was opened and that the metal-robot did something.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
