### PR TITLE
Skip empty code blocks to be added to release draft.

### DIFF
--- a/pkg/webhooks/github/actions/release_drafter_test.go
+++ b/pkg/webhooks/github/actions/release_drafter_test.go
@@ -316,6 +316,18 @@ Some description
 * Some new feature (metal-stack/metal-robot#11) @metal-robot`,
 		},
 		{
+			name:      "ignore empty code blocks",
+			org:       "metal-stack",
+			repo:      "metal-robot",
+			title:     "Some new feature",
+			number:    11,
+			author:    "metal-robot",
+			priorBody: "",
+			prBody:    github.Ptr("This is a new feature\r\n```ACTIONS_REQUIRED\r\n\r\n```"),
+			want: `# Merged Pull Requests
+* Some new feature (metal-stack/metal-robot#11) @metal-robot`,
+		},
+		{
 			name:      "creating fresh release draft with breaking change",
 			org:       "metal-stack",
 			repo:      "metal-robot",


### PR DESCRIPTION
## Description

Contributors from Gardener are used to add empty release notes code blocks, which will lead to empty strings being added to our release drafts. Let's skip empty blocks.

See this PR as an example: https://github.com/metal-stack/gardener-extension-backup-s3/pull/18.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
