### PR TITLE
Fix issue comments only working on pull requests.

### DIFF
--- a/pkg/webhooks/github/actions/issue-comments/handler.go
+++ b/pkg/webhooks/github/actions/issue-comments/handler.go
@@ -24,7 +24,7 @@ type IssueCommentsAction struct {
 }
 
 type Params struct {
-	PullRequestNumber int
+	PullRequestNumber *int
 	RepositoryName    string
 	RepositoryURL     string
 	Comment           string
@@ -102,7 +102,12 @@ func (r *IssueCommentsAction) Handle(ctx context.Context, log *slog.Logger, p *P
 }
 
 func (r *IssueCommentsAction) buildForkPR(ctx context.Context, log *slog.Logger, p *Params) error {
-	pullRequest, _, err := r.client.GetV3Client().PullRequests.Get(ctx, r.client.Organization(), p.RepositoryName, p.PullRequestNumber)
+	if p.PullRequestNumber == nil {
+		log.Info("skipping build-fork-pr comment action because comment not created in a pull request")
+		return nil
+	}
+
+	pullRequest, _, err := r.client.GetV3Client().PullRequests.Get(ctx, r.client.Organization(), p.RepositoryName, *p.PullRequestNumber)
 	if err != nil {
 		return fmt.Errorf("error finding issue related pull request: %w", err)
 	}
@@ -155,13 +160,18 @@ func (r *IssueCommentsAction) buildForkPR(ctx context.Context, log *slog.Logger,
 }
 
 func (r *IssueCommentsAction) tag(ctx context.Context, log *slog.Logger, p *Params, args []string) error {
+	if p.PullRequestNumber == nil {
+		log.Info("skipping tag comment action because comment not created in a pull request")
+		return nil
+	}
+
 	if len(args) == 0 {
 		return fmt.Errorf("no tag name given, skipping")
 	}
 
 	tag := args[0]
 
-	pullRequest, _, err := r.client.GetV3Client().PullRequests.Get(ctx, r.client.Organization(), p.RepositoryName, p.PullRequestNumber)
+	pullRequest, _, err := r.client.GetV3Client().PullRequests.Get(ctx, r.client.Organization(), p.RepositoryName, *p.PullRequestNumber)
 	if err != nil {
 		return fmt.Errorf("error finding issue related pull request: %w", err)
 	}

--- a/pkg/webhooks/github/handlers.go
+++ b/pkg/webhooks/github/handlers.go
@@ -451,19 +451,25 @@ func initHandlers(logger *slog.Logger, cs clients.ClientMap, path string, cfg co
 					commentID    = pointer.SafeDeref(comment.ID)
 					commentlogin = pointer.SafeDeref(user.Login)
 
-					pullRequestLinks = pointer.SafeDeref(issue.PullRequestLinks)
-					pullRequestURL   = pointer.SafeDeref(pullRequestLinks.URL)
+					pullRequestNumber *int
 				)
 
 				if action != githubActionCreated {
 					return nil, handlerrors.SkipOnlyActions(githubActionCreated)
 				}
 
-				parts := strings.Split(pullRequestURL, "/")
-				pullRequestNumberString := parts[len(parts)-1]
-				pullRequestNumber, err := strconv.ParseInt(pullRequestNumberString, 10, 64)
-				if err != nil {
-					return nil, fmt.Errorf("unable to parse pull request number: %w", err)
+				if issue.PullRequestLinks != nil && issue.PullRequestLinks.URL != nil {
+					var (
+						parts                   = strings.Split(*issue.PullRequestLinks.URL, "/")
+						pullRequestNumberString = parts[len(parts)-1]
+					)
+
+					parsedNumber, err := strconv.ParseInt(pullRequestNumberString, 10, 64)
+					if err != nil {
+						return nil, fmt.Errorf("unable to parse pull request number: %w", err)
+					}
+
+					pullRequestNumber = new(int(parsedNumber))
 				}
 
 				return &issue_comments.Params{
@@ -472,7 +478,7 @@ func initHandlers(logger *slog.Logger, cs clients.ClientMap, path string, cfg co
 					Comment:           commentBody,
 					CommentID:         commentID,
 					User:              commentlogin,
-					PullRequestNumber: int(pullRequestNumber),
+					PullRequestNumber: pullRequestNumber,
 				}, nil
 			})
 		default:


### PR DESCRIPTION
## Description

Just saw this in the logs:

```json
{"time":"2026-04-20T10:17:55.500775223Z","level":"ERROR","msg":"error handling event","github-webhook":{"github-event-type":"*github.IssueCommentEvent","github-event-action":"created","github-user":"<redacted>","github-organization-name":"metal-stack","github-repository-url":"<redacted>","github-issue-number":<redacted>,"handler-name":"issue-handling","error":"unable to parse pull request number: strconv.ParseInt: parsing \"\": invalid syntax"}}
```

There are currently no comment actions on non-pull-request comments, but it's still worth fixing it to keep the logs clean and for the future.

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
