### PR TITLE
Fix build regression.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-FROM alpine:3.23
-RUN apk add --no-cache ca-certificates
+FROM gcr.io/distroless/static-debian13:nonroot
 COPY bin/metal-robot /metal-robot
 CMD ["/metal-robot"]

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ BINARY := metal-robot
 MAINMODULE := github.com/metal-stack/metal-robot/cmd/metal-robot
 KUBECONFIG := $(or ${KUBECONFIG},.kubeconfig)
 
+CGO_ENABLED := 1
+LINKMODE := -extldflags '-static -s -w'
+
 SHA := $(shell git rev-parse --short=8 HEAD)
 GITVERSION := $(shell git describe --long --all)
 BUILDDATE := $(shell date -Iseconds)
@@ -21,7 +24,7 @@ start: all
 
 .PHONY: build
 build:
-	go build \
+	go build -tags netgo,osusergo \
 		-ldflags "$(LINKMODE) -X 'github.com/metal-stack/v.Version=$(VERSION)' \
 					   -X 'github.com/metal-stack/v.Revision=$(GITVERSION)' \
 					   -X 'github.com/metal-stack/v.GitSHA1=$(SHA)' \


### PR DESCRIPTION
## Description

Fixes regression of https://github.com/metal-stack/metal-robot/pull/110 that the binary was not built statically.

Also changed to distroless.

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
